### PR TITLE
changes to calc_streak to prevent silent failure

### DIFF
--- a/R/calc_streak.R
+++ b/R/calc_streak.R
@@ -1,18 +1,26 @@
 #' calc_streak
 #' 
-#' @param x A sequence of \code{"H"} and \code{"M"} values indicating a sequence
-#'   of hit or missed shots.
+#' @param x A sequence of two values (default is  \code{"H"} and \code{"M"}) indicating a sequence
+#'   of possible outcomes for a binary variable. For example,  \code{"H"} and \code{"M"} could indicate 
+#'   hits and misses in basketball shots, or \code{"heads"} and \code{"tails"} could indicate coin flips.
+#'
+#' @param streakvar The value that you are interested in studying. Defaults to \code{"H"} but could be
+#'  changed to \code{"heads"} or whatever other response you were interested in studying.
 #'   
 #' @return A vector of the streak lengths. A streak is defined as a series of
-#'   hits \code{"H"} followed by a miss \code{"M"}.
+#'   of repeated instances of the \code{streakvar}, followed by the other binary outcome.
+#'   For example, a series of hits (\code{"H"}) followed by a miss (\code{"M"}).
 #' @export
 #' 
 #' @examples
 #' sequence <- c("H", "H", "M", "H", "M", "M", "H", "H", "H")
 #' calc_streak(sequence)
-calc_streak <- function(x){
+calc_streak <- function(x, streakvar = "H"){
+  if (nchar(as.character(x[1]))>1 & streakvar == "H"){
+    warning("Expecting a sequence of 'H' and 'M's. Please try again with the appropriate type of sequence, or specify the streakvar parameter.")
+  }
   y <- rep(0,length(x))
-  y[x == "H"] <- 1
+  y[x == streakvar] <- 1
   y <- c(0, y, 0)
   wz <- which(y == 0)
   streak <- diff(wz) - 1

--- a/man/calc_streak.Rd
+++ b/man/calc_streak.Rd
@@ -4,15 +4,20 @@
 \alias{calc_streak}
 \title{calc_streak}
 \usage{
-calc_streak(x)
+calc_streak(x, streakvar = "H")
 }
 \arguments{
-\item{x}{A sequence of \code{"H"} and \code{"M"} values indicating a sequence
-  of hit or missed shots.}
+\item{x}{A sequence of two values (default is  \code{"H"} and \code{"M"}) indicating a sequence
+  of possible outcomes for a binary variable. For example,  \code{"H"} and \code{"M"} could indicate
+  hits and misses in basketball shots, or \code{"heads"} and \code{"tails"} could indicate coin flips.}
+
+\item{streakvar}{The value that you are interested in studying. Defaults to \code{"H"} but could be
+ changed to \code{"heads"} or whatever other response you were interested in studying.}
 }
 \value{
 A vector of the streak lengths. A streak is defined as a series of
-  hits \code{"H"} followed by a miss \code{"M"}.
+  of repeated instances of the \code{streakvar}, followed by the other binary outcome.
+  For example, a series of hits (\code{"H"}) followed by a miss (\code{"M"}).
 }
 \description{
 calc_streak


### PR DESCRIPTION
This function was a little too specialized before. In the probability lab, students were accidentally running it on a sequence of "heads" and "tails", saving the results, and trying to plot them. They knew the plot looked wrong (one tall bar at 0 instead of a distribution) but it was hard for them to troubleshoot back to the source.
- Added a warning message so it is clear when it has failed.
- Parameter streakvar allows the function to be used on other types of streaks if desired. 